### PR TITLE
create collector base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 
 ### New
+
+* introduce `CollectorBase` class to derive new collectors from
+* introduce  class to derive new collectors from
 * add netdev collector for network information and statistics
 
 ### Changes
-* * reduce docker image size
-* * we switched base image from python:3-slim to alpine
+
+* reduce docker image size
+* we switched base image from python:3-slim to alpine
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ docker run -d --net="host" --pid="host" -v "/:/host:ro,rslave" p3exporter:latest
 
 Name | Description
 ---- | -----------
+example | example collector that actually does nothing but show how long a function has been executed
 loadavg | collects average load in 1, 5 and 15 minutes interval
 netdev | collects netword device information and statistics
-my | example collector that actually does nothing but show how long a function has been executed
 
 ### Activation and Deactivation of collectors
 

--- a/p3.yml
+++ b/p3.yml
@@ -1,8 +1,8 @@
 exporter_name: "Python prammable Prometheus exporter"
 collectors:
+  - example
   - loadavg
   - netdev
-  - my
 credentials:
 collector_opts:
   netdev:

--- a/p3exporter/collector/__init__.py
+++ b/p3exporter/collector/__init__.py
@@ -1,6 +1,7 @@
 """Entry point for collector sub module."""
 import inflection
 import logging
+import re
 
 from importlib import import_module
 from prometheus_client.core import REGISTRY
@@ -28,6 +29,32 @@ class CollectorConfig(object):
                 self.credentials['ssh_key'] is None or (
                     self.credentials['username'] is None or self.credentials['password'] is None)):
             raise Exception('Credential is not fully configured.')
+
+
+class CollectorBase(object):
+    """Base class for all collectors.
+
+    This class will provide methods that do generic work.
+    """
+
+    def __init__(self, config: CollectorConfig):
+        self.collector_name = self.collector_name_from_class
+        self.opts = config.collector_opts.pop(self.collector_name, {})
+
+
+    @property
+    def collector_name_from_class(self):
+        """Convert class name to controller name.
+
+        The class name must follow naming convention:
+            * camemlized string
+            * first part is the collector name
+            * ends with 'Collector'
+
+        This will convert MyCollector class name to my collector name.
+        """
+
+        return re.sub(r'([A-Z][a-z]+)', r'_\g<0>', self.__class__.__name__).lower().strip('_').split('_')[0]
 
 
 class Collector(object):

--- a/p3exporter/collector/example.py
+++ b/p3exporter/collector/example.py
@@ -1,10 +1,11 @@
 import random
 import time
 
-from p3exporter.collector import CollectorConfig
+from p3exporter.collector import CollectorBase, CollectorConfig
 from prometheus_client.core import GaugeMetricFamily
 
-class MyCollector(object):
+
+class ExampleCollector(CollectorBase):
     """A sample collector.
 
     It does not really do much. It only runs a method and return the time it runs as a gauge metric.
@@ -12,7 +13,7 @@ class MyCollector(object):
 
     def __init__(self, config: CollectorConfig):
         """Instanciate a MyCollector object."""
-        pass
+        super(ExampleCollector, self).__init__(config)
 
     def collect(self):
         """Collect the metrics."""

--- a/p3exporter/collector/loadavg.py
+++ b/p3exporter/collector/loadavg.py
@@ -1,13 +1,14 @@
 import os
 
-from p3exporter.collector import CollectorConfig
+from p3exporter.collector import CollectorBase, CollectorConfig
 from prometheus_client.core import GaugeMetricFamily
 
-class LoadavgCollector(object):
+class LoadavgCollector(CollectorBase):
 
     def __init__(self, config: CollectorConfig):
         """Instanciate a CpuCollector object."""
-        pass
+
+        super(LoadavgCollector, self).__init__(config)
 
     def collect(self):
         """Collect load avg for 1, 5 and 15 minutes interval.

--- a/p3exporter/collector/netdev.py
+++ b/p3exporter/collector/netdev.py
@@ -1,15 +1,16 @@
 import netifaces
 
-from p3exporter.collector import CollectorConfig
+from p3exporter.collector import CollectorBase, CollectorConfig
 from prometheus_client.core import CounterMetricFamily, InfoMetricFamily
 
-class NetdevCollector(object):
 
-    name = "netdev"
+class NetdevCollector(CollectorBase):
 
     def __init__(self, config: CollectorConfig):
         """Instanciate a NetdevCollector object."""
-        self.opts = config.collector_opts.pop(self.name, {})
+
+        super(NetdevCollector, self).__init__(config)
+
         self.whitelist = self.opts.pop("whitelist", [])
         self.blacklist = self.opts.pop("blacklist", [])
         self.ifaces = []


### PR DESCRIPTION
We decided to provide a base class for all collectors to provide methods
and properties which are useful and/or needed by other collectors.
First property is here `controller_name_from_class` which calculate the
collector name from `__class__.__name__`.
As we want to use `CollectorBase` to provide common features to all
collectors we moved loading of collector options from config to it.
Within this Change we also rename the example collector from `my` to
`example` to be more common in naming.
