### PR TITLE
implement simple lru cache module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### New
 
 * introduce `CollectorBase` class to derive new collectors from
+* added cache module with timed lru cache
 * add netdev collector for network information and statistics
 
 ### Changes

--- a/docs/plugins/p3exporter.cache.rst
+++ b/docs/plugins/p3exporter.cache.rst
@@ -1,0 +1,7 @@
+p3exporter.cache package
+========================
+
+.. automodule:: p3exporter.cache
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/plugins/p3exporter.rst
+++ b/docs/plugins/p3exporter.rst
@@ -12,6 +12,7 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
+   p3exporter.cache
    p3exporter.collector
 
 Submodules

--- a/p3exporter/cache/__init__.py
+++ b/p3exporter/cache/__init__.py
@@ -1,0 +1,33 @@
+from functools import lru_cache, wraps
+from datetime import datetime, timedelta
+
+def timed_lru_cache(lifetime: int = 3600, maxsize: int = 128):
+    """Provide cache with a given lifetime.
+
+    This function has to be used as decorator.
+
+    Each time the the cache will be accessed the decorator checks current date is past experation date.
+    If so, the cache will cleared and the new expiration data will be recomputed. If not the cache entry
+    will be delivered.
+
+    :param lifetime: The lifetime of cache in seconds, defaults to 3600
+    :type lifetime: int, optional
+    :param maxsize: The maximum number of cache items, defaults to 128
+    :type maxsize: int, optional
+    """
+    def wrapper_cache(func):
+        func = lru_cache(maxsize=maxsize)(func)
+        func.lifetime = timedelta(seconds=lifetime)
+        func.expiration = datetime.utcnow() + func.lifetime
+
+        @wraps(func)
+        def wrapped_func(*args, **kwargs):
+            if datetime.utcnow() >= func.expiration:
+                func.cache_clear()
+                func.expiration = datetime.utcnow() + func.lifetime
+
+            return func(*args, **kwargs)
+
+        return wrapped_func
+
+    return wrapper_cache

--- a/p3exporter/collector/example.py
+++ b/p3exporter/collector/example.py
@@ -1,8 +1,6 @@
 import random
 import time
 
-from prometheus_client.metrics import Info
-
 from p3exporter.collector import CollectorBase, CollectorConfig
 from p3exporter.cache import timed_lru_cache
 from prometheus_client.core import GaugeMetricFamily, InfoMetricFamily


### PR DESCRIPTION
Insert a first version of cache module. We simply provide a timed
version of lru_cache function from functools.
Provide documentation for that cache module.

To show how timed_lru_cache can be applied we add it to the test
function `_run_process`. The behavior can be observed in web browser. If
values comes from cache you see sth like that:

```
example_process_runtime 1.0783000107039697e-05
```

You see the process runtime prefixed with `e-05`, that indicates a
runtime in milliseconds.
