### PR TITLE
Fix #34 - support module names with underscore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 
+* #34 - custom collectors with underscore in name are not supported
+
 ### Breaks
 
 ## 1.1.1 - (2021-04-12)

--- a/p3exporter/collector/__init__.py
+++ b/p3exporter/collector/__init__.py
@@ -38,13 +38,20 @@ class CollectorBase(object):
         """Convert class name to controller name.
 
         The class name must follow naming convention:
-            * camemlized string
-            * first part is the collector name
+            * camelized string
+            * starts with camelized module name
             * ends with 'Collector'
 
-        This will convert MyCollector class name to my collector name.
+        This will convert <Name>Collector class name to <name> collector name.
+        Examples for valid names:
+            * MyCollector => my
+            * FooBarCollector => foo_bar
+            * FooBarBazCollector => foo_bar_baz
         """
-        return re.sub(r'([A-Z][a-z]+)', r'_\g<0>', self.__class__.__name__).lower().strip('_').split('_')[0]
+        class_name = re.sub(r'(?<=[a-z])[A-Z]|[A-Z](?=[^A-Z])', r'_\g<0>', self.__class__.__name__).lower().strip('_')
+        class_name_parts = class_name.split('_')[0:-1]
+
+        return '_'.join(class_name_parts)
 
 
 class Collector(object):


### PR DESCRIPTION
With this fix camelized collector names like `FooBarBazCollector` will
lead to module name `foo_bar_baz`.
Adapt docstring to reflect the new behavior. 
This change is a non-breaking one.