### PR TITLE
Allow fully qualified collector modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ## Unreleased
 
 ### New
+* Allow to load external collectors with fully qualified dotted notation
 
 ### Changes
 * Switch sphinx from recommonmark to myst_parser

--- a/p3.yml
+++ b/p3.yml
@@ -1,6 +1,6 @@
 exporter_name: "Python prammable Prometheus exporter"
 collectors:
-  - example
+  - p3exporter.collector.example
   - loadavg
   - netdev
 collector_opts:


### PR DESCRIPTION
To make development of collectors more indipendent from p3exporter developments we now allow fully qualified (dotted notation) module names. Naming convention of collector class stay in place.